### PR TITLE
Better publish GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       Solution_Name: SCTools
       Build_Config: Release
+      Build_Version: {{ github.event.inputs.version }}
 
     steps:
     - name: Checkout
@@ -28,7 +29,7 @@ jobs:
       run: dotnet restore $env:Solution_Name
       
     - name: Build solution
-      run: msbuild $env:Solution_Name /p:Configuration=$env:Build_Config /property:Version={{ github.event.inputs.version }}
+      run: msbuild $env:Solution_Name /p:Configuration=$env:Build_Config /property:Version=$env:Build_Version
     
     - name: Publish to folder
       run: dotnet publish $env:Solution_Name -c $env:Build_Config /p:PublishProfile=FolderProfile.pubxml --no-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       run: dotnet restore $env:Solution_Name
       
     - name: Build solution
-      run: msbuild $env:Solution_Name /p:Configuration=$env:Build_Config
+      run: msbuild $env:Solution_Name /p:Configuration=$env:Build_Config /property:Version={{ github.event.inputs.version }}
     
     - name: Publish to folder
       run: dotnet publish $env:Solution_Name -c $env:Build_Config /p:PublishProfile=FolderProfile.pubxml --no-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       Solution_Name: SCTools
       Build_Config: Release
-      Build_Version: {{ github.event.inputs.version }}
+      Build_Version: ${{ github.event.inputs.version }}
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Take application version from input parameters when build to guratee release version with git tag match application version always. Otherwise application might do infinite updating in loop since local version is not updated to correctly